### PR TITLE
Retry Rebooting

### DIFF
--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -490,7 +490,8 @@ function AddDevice(device) {
         "reapplied": false,
         "builds": 0,
         "rebooted_time": 0,
-        "retry_reboot": false
+        "retry_reboot": false,
+        "reboots": 0
     };
     if(!devices[device.uuid].lastSeen) {
         devices[device.uuid].lastSeen = "Never"
@@ -794,7 +795,7 @@ function RebootWarnDevice(manDevices) {
             if(lastSeen > warningTime) {
                 if(!config.excludeFromReboots.includes(deviceName)) {
                     warnedDevices.push(device.name);
-                    if(devices[deviceName].rebooted && Date.now() - devices[deviceName].rebooted_time > rebootTime ) {
+                    if(devices[deviceName].rebooted && devices[deviceName].reboots < config.maxRebootRetries && Date.now() - devices[deviceName].rebooted_time > rebootTime ) {
                         devices[deviceName].retry_reboot = true;
                     }
                 }
@@ -829,6 +830,7 @@ function RebootWarnDevice(manDevices) {
                 devices[warnedDevices[i]].rebooted = true;
                 devices[warnedDevices[i]].rebooted_time = Date.now();
                 devices[warnedDevices[i]].retry_reboot = false;
+                devices[warnedDevices[i]].reboots = devices[warnedDevices[i]].reboots + 1;
             }
         }
     }
@@ -837,6 +839,7 @@ function RebootWarnDevice(manDevices) {
             devices[deviceName].rebooted = false;
             devices[deviceName].rebooted_time = 0;
             devices[deviceName].retry_reboot = false;
+            devices[deviceName].reboots = 0;
             console.info(GetTimestamp() + `Device ${devices[deviceName].name} has come back online from rebooting the device`);
         }
     }

--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -14,6 +14,7 @@ const warningTime = config.warningTime * 60000;
 const offlineTime = config.offlineTime * 60000;
 const rebuildTime = config.rebuildTime * 60000;
 const reopenTime = config.reopenTime * 60000;
+const rebootTime = config.rebootAgainTimer * 60000;
 //const reapplySAMTime = config.reapplySAMTime * 60000;
 const okColor = 0x008000;
 const warningColor = 0xFFFF00;
@@ -487,7 +488,9 @@ function AddDevice(device) {
         "rebooted": false,
         "reopened": false,
         "reapplied": false,
-        "builds": 0
+        "builds": 0,
+        "rebooted_time": 0,
+        "retry_reboot": false
     };
     if(!devices[device.uuid].lastSeen) {
         devices[device.uuid].lastSeen = "Never"
@@ -791,12 +794,15 @@ function RebootWarnDevice(manDevices) {
             if(lastSeen > warningTime) {
                 if(!config.excludeFromReboots.includes(deviceName)) {
                     warnedDevices.push(device.name);
+                    if(devices[deviceName].rebooted && Date.now() - devices[deviceName].rebooted_time > rebootTime ) {
+                        devices[deviceName].retry_reboot = true;
+                    }
                 }
             }
         }
     }
     for(var i = 0; i < warnedDevices.length; i++) {
-        if(!devices[warnedDevices[i]].rebooted || manDevices) {
+        if(!devices[warnedDevices[i]].rebooted || manDevices || devices[warnedDevices[i]].retry_reboot) {
             for(var ii = 0; ii < config.rebootMonitorURL.length; ii++) {
                 const options = {
                     url: config.rebootMonitorURL[ii],
@@ -821,12 +827,16 @@ function RebootWarnDevice(manDevices) {
                 });
                 SendRebootAlert(warnedDevices[i]);
                 devices[warnedDevices[i]].rebooted = true;
+                devices[warnedDevices[i]].rebooted_time = Date.now();
+                devices[warnedDevices[i]].retry_reboot = false;
             }
         }
     }
     for(var deviceName in devices) {
         if(devices[deviceName].rebooted && warnedDevices.indexOf(deviceName) == -1) {
             devices[deviceName].rebooted = false;
+            devices[deviceName].rebooted_time = 0;
+            devices[deviceName].retry_reboot = false;
             console.info(GetTimestamp() + `Device ${devices[deviceName].name} has come back online from rebooting the device`);
         }
     }

--- a/RDMMonitorConfig.example.json
+++ b/RDMMonitorConfig.example.json
@@ -47,6 +47,7 @@
 
     "allowWarnReboots": true,
     "rebootAgainTimer": 5,
+    "maxRebootRetries": 10,
     "rebootMonitorURL": ["http://192.168.0.1:6542","http://192.168.0.1:6543"],
     "sendRebootAlerts": false,
     "excludeFromReboots": ["Device01","Device02"],

--- a/RDMMonitorConfig.example.json
+++ b/RDMMonitorConfig.example.json
@@ -46,6 +46,7 @@
     "excludeFromReapplySAM": ["Device01","Device02"],
 
     "allowWarnReboots": true,
+    "rebootAgainTimer": 5,
     "rebootMonitorURL": ["http://192.168.0.1:6542","http://192.168.0.1:6543"],
     "sendRebootAlerts": false,
     "excludeFromReboots": ["Device01","Device02"],

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ reapplySAMMonitorURL: An array of strings for the URLs of the reapply SAM monito
 excludeFromReapplySAM: An array of strings that are the unique names of the devices to exclude from the reapply SAM request
 
 allowWarnReboots: true/false - Bool to enable RDMDeviceMonitor to send a reboot request to a monitor
+rebootAgainTimer: The time in minutes to wait before trying another reboot, in case the last reboot did not bring the device online
 rebootMonitorURL: An array of strings for the URLs of the reboot monitors you are using like iPhone Controller or DCM Listener
 sendRebootAlerts: true/false - Bool to enable the DM message for rebooting a device
 excludeFromReboots: An array of strings that are the unique names of the devices to exclude from the reboot request

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ excludeFromReapplySAM: An array of strings that are the unique names of the devi
 
 allowWarnReboots: true/false - Bool to enable RDMDeviceMonitor to send a reboot request to a monitor
 rebootAgainTimer: The time in minutes to wait before trying another reboot, in case the last reboot did not bring the device online
+maxRebootRetries: A number for limiting the amount of times a device is rebooted
 rebootMonitorURL: An array of strings for the URLs of the reboot monitors you are using like iPhone Controller or DCM Listener
 sendRebootAlerts: true/false - Bool to enable the DM message for rebooting a device
 excludeFromReboots: An array of strings that are the unique names of the devices to exclude from the reboot request


### PR DESCRIPTION
I setup the reboot logic to check at a configurable amount of time and reboot device until they are online. If you set the timer to 5 minutes, it will do the initial reboot at the warning time (if enabled), wait 5 minutes if it doesn't come online, reboot the device again, and repeat until it hits the max reboot setting. The initial reboot from hitting the warning timer counts as the first attempt.

This is related to issue #7 for reattempting reboots.