### PR TITLE
Allow manual commands when auto reboot/reopen are disabled

### DIFF
--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -788,7 +788,7 @@ function SendOfflineDeviceDMs() {
 }
 
 function ReopenWarnGame(manDevices) {
-    if(!config.allowReopenGame) {
+    if(!config.allowReopenGame && !manDevices) {
         return;
     }
     let now = new Date();
@@ -849,7 +849,7 @@ function ReopenWarnGame(manDevices) {
 }
 
 function ReapplySAM(manDevices) {
-    if(!config.allowReapplySAM) {
+    if(!config.allowReapplySAM && !manDevices) {
         return;
     }
     let now = new Date();
@@ -910,7 +910,7 @@ function ReapplySAM(manDevices) {
 }
 
 function RebootWarnDevice(manDevices) {
-    if(!config.allowWarnReboots) {
+    if(!config.allowWarnReboots && !manDevices) {
         return;
     }
     let now = new Date();
@@ -1156,6 +1156,7 @@ function GetDeviceString(deviceList) {
     }
     return currentString;
 }
+
 function GetDeviceDetailedString(deviceList) {
     let currentString = "";
     for(let i = 0; i < deviceList.length; i++) {


### PR DESCRIPTION
When auto reboots and reopens are disabled, they would also block users from sending discord commands to reboot or reopen a device. This PR updates the check and allows manual commands while the auto features are disabled. 