### PR TITLE
Add custom config support instead of duplicating directories

### DIFF
--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -7,7 +7,6 @@ const configPath = args.length > 0
     ? path.resolve(__dirname, args[0])
     : './RDMMonitorConfig.json';
 const config = require(configPath);
-const config = require('./RDMMonitorConfig.json');
 const warningImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/warned.png";
 const okImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/ok.png";
 const offlineImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/offline.png";

--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -1,6 +1,11 @@
 const Discord = require('discord.js');
 const bot = new Discord.Client();
 const request = require('request');
+const args = process.argv.splice(2);
+const configPath = args.length > 0
+    ? `./${args[0]}`
+    : './RDMMonitorConfig.json';
+const config = require(configPath);
 const config = require('./RDMMonitorConfig.json');
 const warningImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/warned.png";
 const okImage = "https://raw.githubusercontent.com/chuckleslove/RDMMonitor/master/static/ok.png";

--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -1,9 +1,10 @@
 const Discord = require('discord.js');
 const bot = new Discord.Client();
 const request = require('request');
+const path = require('path');
 const args = process.argv.splice(2);
 const configPath = args.length > 0
-    ? `./${args[0]}`
+    ? path.resolve(__dirname, args[0])
     : './RDMMonitorConfig.json';
 const config = require(configPath);
 const config = require('./RDMMonitorConfig.json');

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ adminRoleName: This is a string for the name of the main role that will admin th
 
 # LAUNCHING IT
 
-Using terminal, run `node RDMMonitor.js`
+Using terminal, run `node RDMMonitor.js` or `node RDMMonitor.js config.json` if specifying a config file.
 
    * If you close that window, the bot connection will be terminated! You can add it to PM2 if you want it to run in the background.
 


### PR DESCRIPTION
PR'd this almost 2 years ago in the original repo, basic implementation but it works fine from my tests. (personally still a use slimmed down version of original RDMMonitor with this code too)  
https://github.com/chuckleslove/RDMMonitor/pull/4

Could expand it to check if the file exists, otherwise throw an error or use the default config file.