### PR TITLE
Support Remote Command Execution

### DIFF
--- a/RDMMonitorConfig.example.json
+++ b/RDMMonitorConfig.example.json
@@ -59,6 +59,9 @@
     "excludeFromReboots": ["Device01","Device02"],
     
     "brightnessMonitorURL": ["http://192.168.0.1:6542","http://192.168.0.1:6543"],
+    
+    "allowCMD": false,
+    "cmdMonitorURL": ["http://192.168.0.1:6542","http://192.168.0.1:6543"],
 
     "cmdPrefix": ".",
     "adminRoleName": "ADMIN-ROLE-NAME"

--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ RDMDeviceMonitor is a simple discord bot to monitor device status for RDM.
 # SETTINGS
 ```
 token: Mandator, discord bot token, bot should have send message and manage message permissions in the designated channel
+
 channel: Default channel ID of where to post device/instance status
 deviceStatusChannel: Specific channel ID of where to post device status
 instanceStatusChannel: Specific channel ID of where to post instance status
 deviceSummaryChannel: Specific channel ID of where to post the device summary
+deviceDetailedSummaryChannel: Specific channel ID of where to post the device detailed summary
+questChannel: Specific channel ID of where to post the quest instance details
 
 userAlerts: an array of user IDs to DM upon device going offline
+
 url: URL of your RDM website, by default IP:9000 but can use actual URL if you have a properly configured reverse proxy
 websiteLogin: Username to login with
 websitePassword: Password for the username
@@ -49,6 +53,8 @@ The above user must have admin access to the website
 postIndividualDevices: true/false - Bool to post each device individually
 postInstanceStatus: true/false - Bool to post instance status
 postDeviceSummary: true/false - Bool to post device status in a single block by current status
+postDeviceDetailedSummary: true/false - Bool to post device detailed status in a single block by current status
+postQuestSummary: true/false - Bool to post quest instance status in a single block by current status
 
 showInstance: Show which instance a device is assigned to on the individual device post
 showAccount: Show account assigned on device post
@@ -61,6 +67,8 @@ clearMessagesOnStartup: Will delete all messages in the channel it is going to p
 
 ignoredDevices: An array of strings for the overall device blacklist
 ignoredInstances: An array of strings for the instance blacklist
+ignoredQuestInstances: An array of strings for the quest instance blacklist
+
 postingDelay: The time in minutes to delay different posting triggers
 
 warningTime: The time in minutes to consider a device in warning state

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ excludeFromReboots: An array of strings that are the unique names of the devices
 
 brightnessMonitorURL: An array of strings for the URLs of the brightness monitors you are using like iPhone Controller or DCM Listener
 
+allowCMD: true/false - Bool to enable RDMDeviceMonitor to send a request to execute a predefined command on the monitor server
+cmdMonitorURL: An array of strings for the URLs of the monitors you want to send command requests to
+
 cmdPrefix: A single character used to identify commands that the bot should react to
 adminRoleName: This is a string for the name of the main role that will admin the bot
 ```
@@ -118,6 +121,7 @@ Instead, add it to PM2 with `pm2 start ecosystem.config.js`
 --`.reboot <DEVICE-NAMES>`   »   to reboot the specific devices<br>
 --`.sam <DEVICE-NAMES>`   »   to reapply the SAM profile to the specific devices<br>
 --`.brightness <VALUE>, <DEVICE-NAMES>`   »   to change the brightness on the specific devices<br>
+--`.cmd <ALIAS>`   »   to execute a pre-defined command on the listening server<br>
 
 The commands with `<DEVICE-NAMES>` accept multiple names separated by commas.<br>
 They can be used to skip the exclusion list if you specify a name on the list.<br>


### PR DESCRIPTION
Sends the `cmd` type to a remote listener for remote command execution. Use the `.cmd <ALIAS>` command to specify which pre-defined command on the target machine. Note that if you have multiple remote URLS, you should use separate aliases unless you want them to execute on all systems. 

See DCMRL PR #[13](https://github.com/versx/DCMRemoteListener/pull/13) for a working listener.