### PR TITLE
Add Dockerfile for easy Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/.gitignore
+/.dockerignore
+/Dockerfile
+/RDMMonitorConfig.example.json
+/README.md
+/ecosystem.config.js
+
+.git/
+static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+### Build layer: Node.js 18 ###
+FROM node:18-alpine AS build-layer
+WORKDIR /app
+
+# Install Vercel's pkg build tool
+RUN npm install -g pkg
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+# Build the self-contained application
+COPY RDMMonitor.js ./
+RUN pkg -t node18-alpine RDMMonitor.js
+
+### Container ###
+FROM alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build-layer /app/RDMMonitor /app/RDMMonitor
+ENTRYPOINT ["/app/RDMMonitor"]

--- a/RDMMonitor.js
+++ b/RDMMonitor.js
@@ -10,7 +10,7 @@ const path = require('path');
 const args = process.argv.splice(2);
 const configPath = args.length > 0
     ? path.resolve(__dirname, args[0])
-    : './RDMMonitorConfig.json';
+    : path.join(process.cwd(), 'RDMMonitorConfig.json');
 const config = require(configPath);
 const warningImage = "https://raw.githubusercontent.com/Kneckter/RDMMonitor/master/static/warned.png";
 const okImage = "https://raw.githubusercontent.com/Kneckter/RDMMonitor/master/static/ok.png";

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RDMDeviceMonitor is a simple discord bot to monitor device status for RDM.
 
 5. Copy the example file `cp RDMMonitorConfig.example.json RDMMonitorConfig.json`.
 
-6. Create an applicaiton and get the your bot's secret token, and application ID at:
+6. Create an application and get the your bot's secret token, and application ID at:
    * https://discordapp.com/developers/applications/me
 
 7. Get your application/bot to join your server by going here:
@@ -30,6 +30,18 @@ RDMDeviceMonitor is a simple discord bot to monitor device status for RDM.
 8. Fill out the information needed in `nano RDMMonitorConfig.json`.
 
 <hr />
+
+# SETTING UP THE BOT USING DOCKER:
+
+1. Run `git clone https://github.com/Kneckter/RDMMonitor` to copy the bot.
+
+2. Change into the new folder `cd RDMMonitor/`.
+
+3. Build the container `docker build -t rdm-monitor .`
+
+4. Create the application and the configuration file according to step 6-8 from the previous section.
+
+5. Start the Docker container: `docker run -v ./RDMMonitorConfig.json:/app/RDMMonitorConfig.json rdm-monitor`
 
 # SETTINGS
 ```


### PR DESCRIPTION
Given that there is no Dockerfile available for this project yet, I thought I would create one.

This greatly simplifies deployment on Linux servers.

The strategy I chose for deployment is the following:
- First, the application is compiled using Vercel's pkg into a self-contained executable.
- Second, the application is copied into a lightweight Alpine container that can run the self-contained executable.

Note: The configuration file is mounted as a volume into the Docker container.

The resulting Docker image size is 64.2 MB on arm64.

Information regarding the Dockerfile has been added to the README. 